### PR TITLE
feat: Bypass email signup to showcase draft UI immediately

### DIFF
--- a/app/draft-room/page.tsx
+++ b/app/draft-room/page.tsx
@@ -84,19 +84,8 @@ export default function DraftRoomPage() {
     return () => clearInterval(timer);
   }, [currentPick]);
 
-  // Check authentication
-  if (isPending) {
-    return (
-      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
-        <div className="text-lg">Loading...</div>
-      </div>
-    );
-  }
-
-  if (!session) {
-    router.push('/login');
-    return null;
-  }
+  // Allow access without authentication for demo purposes
+  // Users can explore the draft UI and later be prompted to register
 
   const isUserTurn = draftBoard.find(pick => pick.pick === currentPick)?.teamIndex === userTeamIndex;
   

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -29,7 +29,7 @@ export default function Home() {
             </p>
             <div className="flex flex-col sm:flex-row gap-4 justify-center animate-fade-in-up animation-delay-400">
               <Link
-                href="/draft-setup"
+                href="/draft-room"
                 className="btn-firecrawl-orange inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-[10px] text-base font-medium transition-all duration-200 h-12 px-8"
               >
                 Start Draft Setup
@@ -127,7 +127,7 @@ export default function Home() {
           </div>
 
           <div className="text-center mt-12">
-            <Link href="/draft-setup" className="btn-firecrawl-orange inline-flex items-center justify-center whitespace-nowrap rounded-[10px] text-base font-medium transition-all duration-200 h-12 px-8">
+            <Link href="/draft-room" className="btn-firecrawl-orange inline-flex items-center justify-center whitespace-nowrap rounded-[10px] text-base font-medium transition-all duration-200 h-12 px-8">
               Get Started with Your Sport
             </Link>
           </div>
@@ -280,7 +280,7 @@ export default function Home() {
               Make smarter picks with real-time analysis across NFL, NBA, and MLB
             </p>
             <Link
-              href="/draft-setup"
+              href="/draft-room"
               className="btn-firecrawl-default inline-flex items-center justify-center whitespace-nowrap rounded-[10px] text-base font-medium transition-all duration-200 h-12 px-8"
             >
               Start Your Draft
@@ -452,7 +452,7 @@ export default function Home() {
           </p>
           <div className="flex flex-col sm:flex-row gap-4 justify-center">
             <Link
-              href="/draft-setup"
+              href="/draft-room"
               className="btn-firecrawl-orange inline-flex items-center justify-center whitespace-nowrap rounded-[10px] text-base font-medium transition-all duration-200 h-12 px-8"
             >
               Start Draft Setup


### PR DESCRIPTION
## Summary
- Redirect all "Start Draft Setup" buttons from homepage directly to draft room
- Remove authentication checks from draft room page to allow demo access  
- Enable users to experience the full draft interface before registration

## Test plan
- [ ] Click "Start Draft Setup" button on homepage
- [ ] Verify it navigates directly to draft room without authentication
- [ ] Confirm draft room loads and displays properly
- [ ] Test all CTA buttons redirect to draft room consistently

🤖 Generated with [Claude Code](https://claude.ai/code)