### PR TITLE
Fix Vercel build failures by lazy-loading API clients

### DIFF
--- a/app/api/brand-monitor/scrape/route.ts
+++ b/app/api/brand-monitor/scrape/route.ts
@@ -11,9 +11,14 @@ import {
 } from '@/lib/api-errors';
 import { FEATURE_ID_MESSAGES } from '@/config/constants';
 
-const autumn = new Autumn({
-  apiKey: process.env.AUTUMN_SECRET_KEY!,
-});
+function getAutumnClient() {
+  if (!process.env.AUTUMN_SECRET_KEY) {
+    throw new ExternalServiceError('Autumn configuration missing', 'autumn');
+  }
+  return new Autumn({
+    apiKey: process.env.AUTUMN_SECRET_KEY,
+  });
+}
 
 export async function POST(request: NextRequest) {
   try {
@@ -28,6 +33,7 @@ export async function POST(request: NextRequest) {
 
     // Check if user has enough credits (1 credit for URL scraping)
     try {
+      const autumn = getAutumnClient();
       const access = await autumn.check({
         customer_id: sessionResponse.user.id,
         feature_id: FEATURE_ID_MESSAGES,
@@ -63,6 +69,7 @@ export async function POST(request: NextRequest) {
 
     // Track usage (1 credit for scraping)
     try {
+      const autumn = getAutumnClient();
       await autumn.track({
         customer_id: sessionResponse.user.id,
         feature_id: FEATURE_ID_MESSAGES,

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -21,9 +21,14 @@ import {
   UI_LIMITS
 } from '@/config/constants';
 
-const autumn = new Autumn({
-  apiKey: process.env.AUTUMN_SECRET_KEY!,
-});
+function getAutumnClient() {
+  if (!process.env.AUTUMN_SECRET_KEY) {
+    throw new ExternalServiceError('Autumn configuration missing', 'autumn');
+  }
+  return new Autumn({
+    apiKey: process.env.AUTUMN_SECRET_KEY,
+  });
+}
 
 export async function POST(request: NextRequest) {
   try {
@@ -54,6 +59,7 @@ export async function POST(request: NextRequest) {
         featureId: 'messages',
       });
       
+      const autumn = getAutumnClient();
       const access = await autumn.check({
         customer_id: sessionResponse.user.id,
         feature_id: FEATURE_ID_MESSAGES,
@@ -79,6 +85,7 @@ export async function POST(request: NextRequest) {
 
     // Track API usage with Autumn
     try {
+      const autumn = getAutumnClient();
       await autumn.track({
         customer_id: sessionResponse.user.id,
         feature_id: FEATURE_ID_MESSAGES,
@@ -162,6 +169,7 @@ export async function POST(request: NextRequest) {
     // Get remaining credits from Autumn
     let remainingCredits = 0;
     try {
+      const autumn = getAutumnClient();
       const usage = await autumn.check({
         customer_id: sessionResponse.user.id,
         feature_id: FEATURE_ID_MESSAGES,

--- a/app/api/credits/route.ts
+++ b/app/api/credits/route.ts
@@ -4,9 +4,14 @@ import { Autumn } from 'autumn-js';
 import { AuthenticationError, ExternalServiceError, handleApiError } from '@/lib/api-errors';
 import { FEATURE_ID_MESSAGES } from '@/config/constants';
 
-const autumn = new Autumn({
-  apiKey: process.env.AUTUMN_SECRET_KEY!,
-});
+function getAutumnClient() {
+  if (!process.env.AUTUMN_SECRET_KEY) {
+    throw new ExternalServiceError('Autumn configuration missing', 'autumn');
+  }
+  return new Autumn({
+    apiKey: process.env.AUTUMN_SECRET_KEY,
+  });
+}
 
 export async function GET(request: NextRequest) {
   try {
@@ -20,6 +25,7 @@ export async function GET(request: NextRequest) {
     }
 
     // Check feature access for messages
+    const autumn = getAutumnClient();
     const access = await autumn.check({
       customer_id: sessionResponse.user.id,
       feature_id: FEATURE_ID_MESSAGES,

--- a/lib/scrape-utils.ts
+++ b/lib/scrape-utils.ts
@@ -4,9 +4,14 @@ import { Company } from './types';
 import FirecrawlApp from '@mendable/firecrawl-js';
 import { getConfiguredProviders, getProviderModel } from './provider-config';
 
-const firecrawl = new FirecrawlApp({
-  apiKey: process.env.FIRECRAWL_API_KEY,
-});
+function getFirecrawlClient() {
+  if (!process.env.FIRECRAWL_API_KEY) {
+    throw new Error('Firecrawl API key is required for web scraping');
+  }
+  return new FirecrawlApp({
+    apiKey: process.env.FIRECRAWL_API_KEY,
+  });
+}
 
 const CompanyInfoSchema = z.object({
   name: z.string(),
@@ -30,6 +35,7 @@ export async function scrapeCompanyInfo(url: string, maxAge?: number): Promise<C
     
     // For demo purposes, we'll use a simplified approach
     // In production, you'd want to use a proper scraping service like Firecrawl
+    const firecrawl = getFirecrawlClient();
     const response = await firecrawl.scrapeUrl(normalizedUrl, {
       formats: ['markdown'],
       maxAge: cacheAge,

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "stripe": "^18.3.0",
     "tailwind-merge": "^3.3.1",
     "tailwindcss": "^4",
+    "tw-animate-css": "^1.3.5",
     "zod": "^3.23.8"
   },
   "devDependencies": {
@@ -77,7 +78,6 @@
     "eslint": "^9",
     "eslint-config-next": "15.3.5",
     "tsx": "^4.20.3",
-    "tw-animate-css": "^1.3.5",
     "typescript": "^5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@radix-ui/react-slot": "^1.2.3",
     "@radix-ui/react-switch": "^1.2.5",
     "@radix-ui/react-tabs": "^1.1.12",
+    "@tailwindcss/postcss": "^4",
     "@tanstack/react-query": "^5.82.0",
     "ai": "^4.3.17",
     "autumn-js": "^0.0.96",
@@ -62,12 +63,12 @@
     "sonner": "^2.0.6",
     "stripe": "^18.3.0",
     "tailwind-merge": "^3.3.1",
+    "tailwindcss": "^4",
     "zod": "^3.23.8"
   },
   "devDependencies": {
     "@better-auth/cli": "^1.2.12",
     "@eslint/eslintrc": "^3",
-    "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
     "@types/pg": "^8.15.4",
     "@types/react": "^19",
@@ -75,7 +76,6 @@
     "dotenv": "^17.1.0",
     "eslint": "^9",
     "eslint-config-next": "15.3.5",
-    "tailwindcss": "^4",
     "tsx": "^4.20.3",
     "tw-animate-css": "^1.3.5",
     "typescript": "^5"


### PR DESCRIPTION
## Summary
- Fixed Vercel deployment build failures caused by API client initialization errors
- Converted module-level API client instantiation to lazy-loaded functions to prevent build-time errors
- Resolved "Cannot find module '@tailwindcss/postcss'" and "No API key provided" errors

## Changes
- **API Routes**: Modified `app/api/brand-monitor/scrape/route.ts` and `app/api/credits/route.ts` to use lazy-loaded Autumn clients
- **Scrape Utils**: Updated `lib/scrape-utils.ts` to use lazy-loaded FirecrawlApp client
- **Build Process**: Prevents Next.js build-time execution of API routes from failing due to missing environment variables

## Test Plan
- [x] Verified `npm run build` completes successfully
- [x] Confirmed all 33 pages generate without errors
- [x] Tested that API routes still function correctly at runtime
- [x] Validated Tailwind CSS PostCSS integration works properly

🤖 Generated with [Claude Code](https://claude.ai/code)